### PR TITLE
[do not merge] docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.9.5-slim-buster
+
+RUN apt-get update
+
+RUN apt-get install -y bluez bluetooth dbus
+
+
+COPY dbus.conf /etc/dbus-1/session.d/
+
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+COPY setup.cfg ./
+
+RUN pip install .
+
+
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/dbus.conf
+++ b/dbus.conf
@@ -1,0 +1,8 @@
+<policy user="blePeripheral">
+  <allow own="org.bluez"/>
+  <allow send_destination="org.bluez"/>
+  <allow send_interface="org.bluez.GattCharacteristic1"/>
+  <allow send_interface="org.bluez.GattDescriptor1"/>
+  <allow send_interface="org.freedesktop.DBus.ObjectManager"/>
+  <allow send_interface="org.freedesktop.DBus.Properties"/>
+</policy>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,16 +2,14 @@ version: "3"
 services:
   mqtt:
     image: eclipse-mosquitto:2.0.11
-    ports:
-      - "9001:9001"
-      - "1883:1883"
+    network_mode: host
     volumes:
       - mosquittoVolume:/mosquitto
       - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
   pyde1:
     build: .
-    cap_add:
-      - ALL
+    depends_on:
+      - mqtt
     network_mode: host
     privileged: true
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  mqtt:
+    image: eclipse-mosquitto:2.0.11
+    ports:
+      - "9001:9001"
+      - "1883:1883"
+    volumes:
+      - mosquittoVolume:/mosquitto
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
+  pyde1:
+    build: .
+    cap_add:
+      - ALL
+    network_mode: host
+    privileged: true
+volumes:
+  mosquittoVolume: {}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+service dbus start
+bluetoothd &
+
+python ./examples/try_de1.py

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,0 +1,3 @@
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log

--- a/src/pyDE1/api/inbound/http/run.py
+++ b/src/pyDE1/api/inbound/http/run.py
@@ -227,6 +227,6 @@ def run_api_inbound(api_pipe: multiprocessing.connection.Connection):
             )
             return
 
-    server = http.server.HTTPServer(('localhost', 1234),
+    server = http.server.HTTPServer(('0.0.0.0', 1234),
                                     RequestHandler)
     server.serve_forever()

--- a/src/pyDE1/api/outbound/mqtt/run.py
+++ b/src/pyDE1/api/outbound/mqtt/run.py
@@ -54,7 +54,7 @@ def run_api_outbound(api_outbound_queue: multiprocessing.Queue):
 
     MQTT_CLIENT_ID = f"pyDE1@{gethostname()}[{os.getpid()}]"
 
-    MQTT_BROKER_HOSTNAME = '::'
+    MQTT_BROKER_HOSTNAME = '127.0.0.1'
     MQTT_BROKER_PORT = 1883
 
     MQTT_TRANSPORT = 'tcp'


### PR DESCRIPTION
Hey @jeffsf  here is a docker setup using docker-compose. I'm wondering if it works for you and others both on your host machine and the raspberry pi. The main hurdle here is comms with the host machines BT stack through dbus. It works on my raspberry pi zero W but not on my Mac.. for now.

First, you must STOP the bluetoothctl process on the host machine (rpi)
`service bluetoothd stop`

Then `docker-compose up` from the project root on the rpi`

It should build and run the containers in the foreground which includes pyDE1 and an MQTT server

If you don't have docker-compose or docker, `apt-get install docker docker-compose`


On Mac I am getting an error:

```
 $ docker compose up                                                                                                                      
[+] Running 2/0
 ⠿ Container pyde1_mqtt_1                Running                                                                                                          0.0s
 ⠿ Container eb5a86028b54_pyde1_pyde1_1  Recreated                                                                                                        0.1s
Attaching to eb5a86028b54_pyde1_pyde1_1, mqtt_1
eb5a86028b54_pyde1_pyde1_1  | Starting system message bus: dbus.
eb5a86028b54_pyde1_pyde1_1  | 2021-06-25 00:34:38,896 INFO Logger: Logging PID 22 to /usr/src/app/_logs/default.2021-06-25_003438.log
eb5a86028b54_pyde1_pyde1_1  | 2021-06-25 00:34:39,061 INFO Scanner: Scan start
eb5a86028b54_pyde1_pyde1_1  | 2021-06-25 00:34:39,071 WARNING asyncio: Executing <Task pending name='Task-1' coro=<run() running at /usr/src/app/./examples/try_de1.py:70> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0xffffb3b16f40>()] created at /usr/local/lib/python3.9/asyncio/base_events.py:424> cb=[_run_until_complete_cb() at /usr/local/lib/python3.9/asyncio/base_events.py:184] created at /usr/local/lib/python3.9/asyncio/base_events.py:621> took 0.111 seconds
eb5a86028b54_pyde1_pyde1_1  | Traceback (most recent call last):
eb5a86028b54_pyde1_pyde1_1  |   File "/usr/src/app/./examples/try_de1.py", line 201, in <module>
eb5a86028b54_pyde1_pyde1_1  |     loop.run_until_complete(run(
eb5a86028b54_pyde1_pyde1_1  |   File "/usr/local/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
eb5a86028b54_pyde1_pyde1_1  |     return future.result()
eb5a86028b54_pyde1_pyde1_1  |   File "/usr/src/app/./examples/try_de1.py", line 70, in run
eb5a86028b54_pyde1_pyde1_1  |     de1_device = await find_first_de1()
eb5a86028b54_pyde1_pyde1_1  |   File "/usr/local/lib/python3.9/site-packages/pyDE1/find_first.py", line 120, in find_first_de1
eb5a86028b54_pyde1_pyde1_1  |     await scanner.start()
eb5a86028b54_pyde1_pyde1_1  |   File "/usr/local/lib/python3.9/site-packages/bleak/backends/bluezdbus/scanner.py", line 123, in start
eb5a86028b54_pyde1_pyde1_1  |     assert_reply(reply)
eb5a86028b54_pyde1_pyde1_1  |   File "/usr/local/lib/python3.9/site-packages/bleak/backends/bluezdbus/utils.py", line 23, in assert_reply
eb5a86028b54_pyde1_pyde1_1  |     raise BleakDBusError(reply.error_name, reply.body)
eb5a86028b54_pyde1_pyde1_1  | bleak.exc.BleakDBusError: [org.freedesktop.DBus.Error.Spawn.ChildExited] Launch helper exited with unknown return code 1
```
